### PR TITLE
Improve footer controls accessibility and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,63 +38,65 @@
 </head>
 
 <body>
-  <main>
-
-    <div class="sidebar d-flex flex-column flex-shrink-0 p-3 bg-light">
-      <div class="fw-bold fs-2 ms-auto me-auto">JSON Light</div>
-      <hr>
-      <div>
-        <label for="filepicker" class="form-label">Open file in JSON mode</label>
-        <input type="file" class="form-control form-control-sm mb-2" id="filepicker" name="filepicker" accept=".json, .jsonl, .geojson">
-      </div>
-      <div>
-        <label for="jsonlpicker" class="form-label">Open file in JSONL mode</label>
-        <input type="file" class="form-control form-control-sm mb-2" id="jsonlpicker" name="jsonlpicker" accept=".json, .jsonl, .geojson">
-      </div>
-      <div id="jsonl-controls" class="mb-2" style="display: none;">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <button type="button" class="btn btn-outline-secondary btn-sm" id="prev-line">‹</button>
-          <div class="flex-grow-1">
-            <div class="input-group input-group-sm">
-              <input type="number" class="form-control" id="line-input" min="1" value="1">
-              <span class="input-group-text" id="total-lines">/ 0</span>
-            </div>
-          </div>
-          <button type="button" class="btn btn-outline-secondary btn-sm" id="next-line">›</button>
-        </div>
-      </div>
-      <div>
-        <label for="paste" , class="form-label">Paste here</label>
-        <textarea class="form-control form-control-sm" id="paste" rows="10"></textarea>
-      </div>
-      <div class="mt-3">
-        <div class="d-flex gap-2">
-          <button type="button" class="btn btn-outline-primary btn-sm flex-fill" id="expand-all">Expand All</button>
-          <button type="button" class="btn btn-outline-secondary btn-sm flex-fill" id="collapse-all">Collapse All</button>
-        </div>
-      </div>
-      <div class="mb-auto"></div>
-      <div id="file-name-display" class="text-muted small text-break" style="display: none;" title="">
-        No file selected
-      </div>
-      <hr>
-      <div>
-        <a href="https://github.com/bluerose73/jsonlight" class="link-dark">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-github"
-            viewBox="0 0 16 16">
-            <path
-              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8" />
+  <div class="app">
+    <header class="app-header d-flex align-items-center px-4 py-3 text-white">
+      <h1 class="h4 m-0 fw-bold">JSON Light</h1>
+      <div class="ms-auto">
+        <a href="https://github.com/bluerose73/jsonlight" class="link-light" aria-label="JSON Light on GitHub">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8" />
           </svg>
         </a>
       </div>
-    </div>
+    </header>
 
-    <div class="container-fluid p-3 overflow-y-auto font-monospace" id="view">
-    </div>
+    <main class="app-content" role="main">
+      <aside class="app-controls p-3" aria-label="JSON Light controls">
+        <div class="mb-3">
+          <label for="filepicker" class="form-label">Open file in JSON mode</label>
+          <input type="file" class="form-control form-control-sm" id="filepicker" name="filepicker" accept=".json, .jsonl, .geojson">
+        </div>
+        <div class="mb-3">
+          <label for="jsonlpicker" class="form-label">Open file in JSONL mode</label>
+          <input type="file" class="form-control form-control-sm" id="jsonlpicker" name="jsonlpicker" accept=".json, .jsonl, .geojson">
+        </div>
+        <div class="mb-3">
+          <label for="paste" class="form-label">Paste here</label>
+          <textarea class="form-control form-control-sm" id="paste" rows="10"></textarea>
+        </div>
+        <div class="mb-4">
+          <div class="d-flex gap-2">
+            <button type="button" class="btn btn-outline-primary btn-sm flex-fill" id="expand-all">Expand All</button>
+            <button type="button" class="btn btn-outline-secondary btn-sm flex-fill" id="collapse-all">Collapse All</button>
+          </div>
+        </div>
+      </aside>
+      <section class="app-view font-monospace" id="view" aria-live="polite"></section>
+    </main>
+
+    <footer class="app-footer py-2 px-3">
+      <div class="footer-inner d-flex flex-column flex-sm-row align-items-start align-items-sm-center gap-2">
+        <div id="file-name-display" class="text-muted small text-break d-none" title="" aria-live="polite" aria-hidden="true">
+          No file selected
+        </div>
+        <div id="jsonl-controls" class="ms-sm-auto d-none" aria-label="JSON Lines navigation controls" aria-hidden="true">
+          <div class="d-flex align-items-center gap-2">
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="prev-line">‹</button>
+            <div class="flex-grow-1">
+              <div class="input-group input-group-sm">
+                <input type="number" class="form-control" id="line-input" min="1" value="1">
+                <span class="input-group-text" id="total-lines">/ 0</span>
+              </div>
+            </div>
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="next-line">›</button>
+          </div>
+        </div>
+      </div>
+    </footer>
 
     <script src="scripts/bootstrap.bundle.min.js"></script>
     <script src="scripts/jsonlight.js"></script>
-  </main>
+  </div>
 </body>
 
 </html>

--- a/scripts/jsonlight.js
+++ b/scripts/jsonlight.js
@@ -442,14 +442,18 @@ class DesktopDataLoader extends DataLoader {
 
 function updateFileNameDisplay(fileName) {
     const fileNameElement = document.querySelector("#file-name-display");
+    if (!fileNameElement) return;
+
     if (fileName) {
         fileNameElement.textContent = fileName;
         fileNameElement.title = fileName; // Show full name on hover
-        fileNameElement.style.display = "block";
+        fileNameElement.classList.remove("d-none");
+        fileNameElement.setAttribute("aria-hidden", "false");
     } else {
         fileNameElement.textContent = "No file selected";
         fileNameElement.title = "";
-        fileNameElement.style.display = "none";
+        fileNameElement.classList.add("d-none");
+        fileNameElement.setAttribute("aria-hidden", "true");
     }
 }
 
@@ -541,11 +545,17 @@ async function renderJsonlFile(file) {
 }
 
 function showJsonlControls() {
-    document.querySelector("#jsonl-controls").style.display = "block";
+    const controls = document.querySelector("#jsonl-controls");
+    if (!controls) return;
+    controls.classList.remove("d-none");
+    controls.setAttribute("aria-hidden", "false");
 }
 
 function hideJsonlControls() {
-    document.querySelector("#jsonl-controls").style.display = "none";
+    const controls = document.querySelector("#jsonl-controls");
+    if (!controls) return;
+    controls.classList.add("d-none");
+    controls.setAttribute("aria-hidden", "true");
     g_jsonlLoader = null;
 }
 

--- a/styles/jsonlight.css
+++ b/styles/jsonlight.css
@@ -1,23 +1,89 @@
+html,
+body {
+    height: 100%;
+}
+
 body {
     min-height: 100vh;
     min-height: -webkit-fill-available;
+    margin: 0;
+    background-color: #f8f9fb;
 }
 
-html {
-    height: -webkit-fill-available;
+.app {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    min-height: 100vh;
 }
 
-main {
-    display: flex;
-    flex-wrap: nowrap;
-    height: 100vh;
-    overflow-x: auto;
-    overflow-y: hidden;
+.app-header {
+    background: linear-gradient(90deg, #3f63ff, #6aa5ff);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
-.sidebar {
-    width: 240px;
-    /* align-self: stretch; */
+.app-content {
+    display: grid;
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+    min-height: 0;
+}
+
+.app-controls {
+    background: #e7f2ff;
+    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    overflow-y: auto;
+}
+
+.app-view {
+    padding: 1.5rem;
+    overflow: auto;
+    background: #ffffff;
+    min-height: 0;
+}
+
+.app-footer {
+    background: #f0f4ff;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.08);
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+}
+
+.app-footer .btn {
+    min-width: 2.5rem;
+}
+
+.footer-inner {
+    min-height: 3rem;
+}
+
+@media (max-width: 992px) {
+    .app-content {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .app-controls {
+        border-right: none;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    }
+}
+
+@media (max-width: 576px) {
+    .app-header {
+        padding-inline: 1.25rem;
+    }
+
+    .app-controls {
+        padding: 1.25rem;
+    }
+
+    .app-view {
+        padding: 1rem;
+    }
+
+    .footer-inner {
+        align-items: stretch;
+    }
 }
 
 .toggle-button {


### PR DESCRIPTION
## Summary
- wrap the layout content in a semantic main element, add aria attributes, and replace inline display toggles for the footer controls
- tune the grid layout and footer styling for sticky bottom navigation and better responsive behavior
- update the JSONL control script to toggle visibility with utility classes for accessibility states

## Testing
- Manual verification: loaded a sample JSONL file in the viewer

------
https://chatgpt.com/codex/tasks/task_e_68d6d0aaf5388321874cd10c701ed663