### PR TITLE
Handle open-with files reliably in Tauri app

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,19 +96,63 @@
     <script type="module">
       // Import Tauri API if running in Tauri context
       if (window.__TAURI__) {
-        import('https://cdn.jsdelivr.net/npm/@tauri-apps/api@2/event').then(module => {
-          const { listen } = module;
-          
+        Promise.all([
+          import('https://cdn.jsdelivr.net/npm/@tauri-apps/api@2/event'),
+          import('https://cdn.jsdelivr.net/npm/@tauri-apps/api@2/core')
+        ]).then(([eventModule, coreModule]) => {
+          const { listen } = eventModule;
+          const { invoke } = coreModule;
+
+          const processedPaths = window.__JSONLIGHT_OPENED_PATHS ?? new Set();
+          window.__JSONLIGHT_OPENED_PATHS = processedPaths;
+
+          const queue = window.__JSONLIGHT_OPEN_WITH_QUEUE ?? [];
+          window.__JSONLIGHT_OPEN_WITH_QUEUE = queue;
+
+          async function drainQueue() {
+            if (typeof window.handleOpenWithFile !== 'function') {
+              return;
+            }
+
+            while (queue.length > 0) {
+              const file = queue.shift();
+              if (!file || !file.path || processedPaths.has(file.path)) {
+                continue;
+              }
+
+              processedPaths.add(file.path);
+              try {
+                await window.handleOpenWithFile(file.path, file.mode);
+              } catch (error) {
+                console.error('Error handling open-with file:', error);
+              }
+            }
+          }
+
+          window.__JSONLIGHT_DRAIN_OPEN_WITH_QUEUE = drainQueue;
+
+          function enqueueFiles(files = []) {
+            if (!Array.isArray(files)) {
+              return;
+            }
+
+            queue.push(...files);
+            drainQueue();
+          }
+
           // Listen for "open-with" events from Rust backend
           listen('open-with', (event) => {
-            console.log('Open with files:', event.payload);
-            const files = event.payload;
-            
-            if (files && files.length > 0) {
-              const file = files[0]; // Handle first file for now
-              handleOpenWithFile(file.path, file.mode);
-            }
+            enqueueFiles(event.payload || []);
           });
+
+          // Retrieve any pending files that were queued before the frontend was ready
+          invoke('get_pending_open_with_files')
+            .then((files) => {
+              enqueueFiles(files);
+            })
+            .catch(err => {
+              console.error('Failed to retrieve pending open-with files:', err);
+            });
         }).catch(err => {
           console.log('Tauri API not available:', err);
         });

--- a/docs/scripts/jsonlight.js
+++ b/docs/scripts/jsonlight.js
@@ -750,7 +750,7 @@ function collapseAll() {
 async function handleOpenWithFile(filePath, mode) {
     try {
         console.log(`Opening file: ${filePath} in ${mode} mode`);
-        
+
         // Use Tauri's fs API to read the file
         if (window.__TAURI__) {
             const { readTextFile } = await import('https://cdn.jsdelivr.net/npm/@tauri-apps/api@2/fs');
@@ -783,6 +783,14 @@ async function handleOpenWithFile(filePath, mode) {
     }
 }
 
+if (typeof window !== 'undefined') {
+    window.handleOpenWithFile = handleOpenWithFile;
+}
+
 let loader = new WebDataLoader();
 loader.loadObject(welcome);
 renderJSON(loader);
+
+if (typeof window !== 'undefined' && typeof window.__JSONLIGHT_DRAIN_OPEN_WITH_QUEUE === 'function') {
+    window.__JSONLIGHT_DRAIN_OPEN_WITH_QUEUE();
+}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,9 @@ use std::{
     path::{Path, PathBuf},
     sync::Mutex,
 };
-use tauri::{Emitter, RunEvent, State};
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use tauri::RunEvent;
+use tauri::{Manager, State};
 
 #[derive(Default)]
 struct OpenWithState {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use tauri::RunEvent;
-use tauri::{Manager, State};
+use tauri::{Emitter, Manager, State};
 
 #[derive(Default)]
 struct OpenWithState {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,40 +1,109 @@
-use std::path::PathBuf;
-use tauri::Emitter;
+use std::{
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+use tauri::{Emitter, RunEvent, State};
+
+#[derive(Default)]
+struct OpenWithState {
+    pending: Mutex<Vec<OpenWithFile>>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct OpenWithFile {
+    path: String,
+    mode: String,
+}
+
+#[tauri::command]
+fn get_pending_open_with_files(state: State<OpenWithState>) -> Vec<OpenWithFile> {
+    let mut pending = state.pending.lock().expect("open-with mutex poisoned");
+    pending.drain(..).collect()
+}
+
+fn classify_mode(path: &Path) -> &'static str {
+    let extension = path.extension().and_then(|ext| ext.to_str());
+
+    match extension {
+        Some(ext) if ext.eq_ignore_ascii_case("jsonl") => "jsonl",
+        Some(ext) if ext.eq_ignore_ascii_case("json") => "json",
+        Some(ext) if ext.eq_ignore_ascii_case("geojson") => "json",
+        _ => "json",
+    }
+}
+
+fn to_open_with_files<I>(paths: I) -> Vec<OpenWithFile>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    paths
+        .into_iter()
+        .map(|path| OpenWithFile {
+            mode: classify_mode(&path).to_string(),
+            path: path.to_string_lossy().to_string(),
+        })
+        .collect()
+}
+
+fn queue_open_with_files(app: &tauri::AppHandle, files: Vec<OpenWithFile>) {
+    if files.is_empty() {
+        return;
+    }
+
+    if let Some(state) = app.try_state::<OpenWithState>() {
+        let mut pending = state.pending.lock().expect("open-with mutex poisoned");
+        pending.extend(files.clone());
+    }
+
+    if let Err(err) = app.emit_all("open-with", &files) {
+        log::error!("Failed to emit open-with event: {err}");
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .setup(|app| {
-      if cfg!(debug_assertions) {
-        app.handle().plugin(
-          tauri_plugin_log::Builder::default()
-            .level(log::LevelFilter::Info)
-            .build(),
-        )?;
-      }
-      
-      // Handle "Open with" functionality - Windows passes file paths as CLI args
-      let paths: Vec<PathBuf> = std::env::args_os().skip(1).map(PathBuf::from).collect();
-      if !paths.is_empty() {
-        // Emit to frontend with file paths and determine mode based on extension
-        let files_with_mode: Vec<serde_json::Value> = paths.into_iter().map(|path| {
-          let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-          let mode = match extension.to_lowercase().as_str() {
-            "jsonl" => "jsonl",
-            "json" | "geojson" => "json",
-            _ => "json" // default to json mode
-          };
-          serde_json::json!({
-            "path": path.to_string_lossy(),
-            "mode": mode
-          })
-        }).collect();
-        
-        app.emit("open-with", &files_with_mode)?;
-      }
-      
-      Ok(())
-    })
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    let builder = tauri::Builder::default()
+        .manage(OpenWithState::default())
+        .invoke_handler(tauri::generate_handler![get_pending_open_with_files])
+        .setup(|app| {
+            if cfg!(debug_assertions) {
+                app.handle().plugin(
+                    tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .build(),
+                )?;
+            }
+
+            // Handle "Open with" functionality - Windows passes file paths as CLI args
+            let paths: Vec<PathBuf> = std::env::args_os().skip(1).map(PathBuf::from).collect();
+            if !paths.is_empty() {
+                let files_with_mode = to_open_with_files(paths);
+                queue_open_with_files(&app.handle(), files_with_mode);
+            }
+
+            Ok(())
+        });
+
+    builder
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|app_handle, event| {
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            {
+                if let RunEvent::Opened { urls } = event {
+                    let paths = urls
+                        .into_iter()
+                        .filter_map(|url| url.to_file_path().ok())
+                        .collect::<Vec<_>>();
+                    let files_with_mode = to_open_with_files(paths);
+                    queue_open_with_files(app_handle, files_with_mode);
+                }
+            }
+
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            {
+                let _ = app_handle;
+                let _ = event;
+            }
+        });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,10 +54,10 @@ fn queue_open_with_files(app: &tauri::AppHandle, files: Vec<OpenWithFile>) {
 
     if let Some(state) = app.try_state::<OpenWithState>() {
         let mut pending = state.pending.lock().expect("open-with mutex poisoned");
-        pending.extend(files.clone());
+        pending.extend(files.iter().cloned());
     }
 
-    if let Err(err) = app.emit_all("open-with", &files) {
+    if let Err(err) = app.emit("open-with", files) {
         log::error!("Failed to emit open-with event: {err}");
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-  app_lib::run();
+    app_lib::run();
 }


### PR DESCRIPTION
## Summary
- keep pending "open with" requests in shared state and expose helpers to classify files and queue them for the frontend
- enqueue CLI and macOS/iOS open-with events via a common helper while still emitting them to the webview when possible
- run rustfmt, which normalized indentation in the generated build and entrypoint files

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: missing system library `glib-2.0` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e33dd134048321b065e6439ceb8be0